### PR TITLE
Add support for runtimes without gmp

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require_once('/path/to/magic-admin-php/init.php');
 The bindings require the following extensions in order to work properly. If you use Composer, these dependencies should be handled automatically. If you install manually, you'll want to make sure that these extensions are available.
 
 -   [`curl`](https://secure.php.net/manual/en/book.curl.php)
--   [`gmp`](https://www.php.net/manual/en/book.gmp.php) | or `bcmath` (see below)
+-   [`gmp`](https://www.php.net/manual/en/book.gmp.php) | or [`bcmath`](https://www.php.net/manual/en/book.bc.php) (see below)
 
 For optimal performance ensure that your platform has the `gmp` extension installed. If your platform does not support `gmp` then `bcmath` may be used as an alternative, but note that `bcmath` is significantly slower than `gmp`.
 

--- a/README.md
+++ b/README.md
@@ -40,12 +40,14 @@ require_once('/path/to/magic-admin-php/init.php');
 
 ### Dependencies
 
-The bindings require the following extensions in order to work properly:
+The bindings require the following extensions in order to work properly. If you use Composer, these dependencies should be handled automatically. If you install manually, you'll want to make sure that these extensions are available.
 
 -   [`curl`](https://secure.php.net/manual/en/book.curl.php)
--   [`gmp`](https://www.php.net/manual/en/book.gmp.php)
+-   [`gmp`](https://www.php.net/manual/en/book.gmp.php) | or `bcmath` (see below)
 
-If you use Composer, these dependencies should be handled automatically. If you install manually, you'll want to make sure that these extensions are available.
+For optimal performance ensure that your platform has the `gmp` extension installed. If your platform does not support `gmp` then `bcmath` may be used as an alternative, but note that `bcmath` is significantly slower than `gmp`.
+
+Since `gmp` is a required dependency you may need to use the `--ignore-platform-reqs` flag when runnining `composer install` on a platform without the `gmp` extension.
 
 ### Prerequisites
 
@@ -68,7 +70,7 @@ Simple usage for login:
   }
 
   $magic = new \MagicAdmin\Magic('<YOUR_API_SECRET_KEY>');
-  
+
   try {
     $magic->token->validate($did_token);
     $issuer = $magic->token->get_issuer($did_token);

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
     "php": ">=5.6.0",
     "ext-curl": "*",
     "ext-gmp": "*",
-    "digitaldonkey/ecverify": "^1.0"
+    "kornrunner/keccak": "^1.1",
+    "simplito/elliptic-php": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^7.3"

--- a/lib/Resource/Token.php
+++ b/lib/Resource/Token.php
@@ -2,8 +2,8 @@
 
 namespace MagicAdmin\Resource;
 
-use Ethereum\EcRecover;
 use MagicAdmin\Exception;
+use MagicAdmin\Util\Eth;
 
 \define('EXPECTED_DID_TOKEN_CONTENT_LENGTH', 2);
 
@@ -84,7 +84,7 @@ class Token
     {
         list($proof, $claim) = $this->decode($did_token);
 
-        $recovered_address = EcRecover::personalEcRecover(\json_encode($claim), $proof);
+        $recovered_address = Eth::ecRecover(\json_encode($claim), $proof);
 
         if ($recovered_address !== \strtolower($this->get_public_address($did_token))) {
             throw new \MagicAdmin\Exception\DIDTokenException(

--- a/lib/Util/Eth.php
+++ b/lib/Util/Eth.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace MagicAdmin\Util;
+
+use Elliptic\EC;
+use kornrunner\Keccak;
+
+class Eth
+{
+    public static function ecRecover(string $message, string $signature)
+    {
+        $msglen = \strlen($message);
+        $hash = Keccak::hash("\x19Ethereum Signed Message:\n{$msglen}{$message}", 256);
+        $sign = [
+            'r' => \substr($signature, 2, 64),
+            's' => \substr($signature, 66, 64),
+        ];
+        $recid = \ord(\hex2bin(\substr($signature, 130, 2))) - 27;
+
+        if ($recid !== ($recid & 1)) {
+            return false;
+        }
+
+        $ec = new EC('secp256k1');
+        $pubkey = $ec->recoverPubKey($hash, $sign, $recid);
+
+        return '0x' . \substr(Keccak::hash(\substr(\hex2bin($pubkey->encode('hex')), 1), 256), 24);
+    }
+}

--- a/tests/Resource/TokenTest.php
+++ b/tests/Resource/TokenTest.php
@@ -94,3 +94,60 @@ final class TokenDecodeTest extends TestCase
         }
     }
 }
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class TokenValidateTest extends TestCase
+{
+    public $token;
+
+    protected function setUp()
+    {
+        $this->token = new \MagicAdmin\Resource\Token();
+    }
+
+    /**
+     *  @doesNotPerformAssertions
+     */
+    public function testValidate()
+    {
+        $valid_did_token = 'WyIweGUwMjQzNTVlNDI5ZGNhZDM1MTdhZDk5ZWEzNDEwYWJmZDQ1YjBiNjM5OGIwNjY1NGRiYTQxNzljODdlMTYyNzgxNTc1YjA5ODFjNjU4ZjcwMjYwZTQ5MjMwZGE5NDg4YTA0ZDk5NzBlYjM4ZTZmZGRlY2Q2NTA5YTAyN2IwOGI5MWIiLCJ7XCJpYXRcIjoxNTg1MDExMjA0LFwiZXh0XCI6MTkwMDQxMTIwNCxcImlzc1wiOlwiZGlkOmV0aHI6MHhCMmVjOWI2MTY5OTc2MjQ5MWI2NTQyMjc4RTlkRkVDOTA1MGY4MDg5XCIsXCJzdWJcIjpcIjZ0RlhUZlJ4eWt3TUtPT2pTTWJkUHJFTXJwVWwzbTNqOERReWNGcU8ydHc9XCIsXCJhdWRcIjpcImRpZDptYWdpYzpmNTQxNjhlOS05Y2U5LTQ3ZjItODFjOC03Y2IyYTk2YjI2YmFcIixcIm5iZlwiOjE1ODUwMTEyMDQsXCJ0aWRcIjpcIjJkZGY1OTgzLTk4M2ItNDg3ZC1iNDY0LWJjNWUyODNhMDNjNVwiLFwiYWRkXCI6XCIweDkxZmJlNzRiZTZjNmJmZDhkZGRkZDkzMDExYjA1OWI5MjUzZjEwNzg1NjQ5NzM4YmEyMTdlNTFlMGUzZGYxMzgxZDIwZjUyMWEzNjQxZjIzZWI5OWNjYjM0ZTNiYzVkOTYzMzJmZGViYzhlZmE1MGNkYjQxNWU0NTUwMDk1MmNkMWNcIn0iXQ==';
+
+        $this->token->validate($valid_did_token);
+    }
+
+    public function testValidateRaisesErrorIfDidTokenHasInvalidSigner()
+    {
+        $invalid_signer_did_token = 'WyIweDBhNTk4NmE1NDdiMzNhMDAxODIxNmRiNjk0YzNiMDg3YTU3MTk1Nzg4ZTZmMDc2NDg4NzA2ZTQ3ZmFhNjFhYzMzZDczZTM4ZmM5ZDA0YzU2YWVmZWNiMTAxMDA4OGEwNmFlOWFiZTE5ZDIyYWQ4MzNiMDhhM2VlNWNmZWM5ZDQ0MWMiLCJ7XCJpYXRcIjoxNTg1MDEwODIxLFwiZXh0XCI6MTkwMDQxMDgyMSxcImlzc1wiOlwiXFxcImRpZDpldGhyOjB4MDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMDAwMFxcXCJcIixcInN1YlwiOlwiNnRGWFRmUnh5a3dNS09PalNNYmRQckVNcnBVbDNtM2o4RFF5Y0ZxTzJ0dz1cIixcImF1ZFwiOlwiZGlkOm1hZ2ljOjMzZjAxNGVlLTNkZDUtNGRmZi1iYzE2LTgxNTU3MTFiN2UwMlwiLFwibmJmXCI6MTU4NTAxMDgyMSxcInRpZFwiOlwiOGEzYjdkZDUtZTFjZi00OTY1LWFlMmItZDIwZjE4OGU2ZWMyXCIsXCJhZGRcIjpcIjB4OTFmYmU3NGJlNmM2YmZkOGRkZGRkOTMwMTFiMDU5YjkyNTNmMTA3ODU2NDk3MzhiYTIxN2U1MWUwZTNkZjEzODFkMjBmNTIxYTM2NDFmMjNlYjk5Y2NiMzRlM2JjNWQ5NjMzMmZkZWJjOGVmYTUwY2RiNDE1ZTQ1NTAwOTUyY2QxY1wifSJd';
+
+        try {
+            $this->token->validate($invalid_signer_did_token);
+        } catch (\MagicAdmin\Exception\DIDTokenException $e) {
+            static::assertSame($e->getMessage(), 'Signature mismatch between "proof" and "claim". Please generate a new token with an intended issuer.');
+        }
+    }
+
+    public function testValidateRaisesErrorIfDidTokenIsExpired()
+    {
+        $expired_did_token = 'WyIweGE3MDUzYzg3OTI2ZjMzZDBjMTZiMjMyYjYwMWYxZDc2NmRiNWY3YWM4MTg2MzUyMzY4ZjAyMzIyMGEwNzJjYzkzM2JjYjI2MmU4ODQyNWViZDA0MzcyZGU3YTc0NzMwYjRmYWYzOGU0ZjgwNmYzOTJjMTVkNzY2YmVkMjVlZmUxMWIiLCJ7XCJpYXRcIjoxNTg1MDEwODM1LFwiZXh0XCI6MTU4NTAxMDgzNixcImlzc1wiOlwiZGlkOmV0aHI6MHhCMmVjOWI2MTY5OTc2MjQ5MWI2NTQyMjc4RTlkRkVDOTA1MGY4MDg5XCIsXCJzdWJcIjpcIjZ0RlhUZlJ4eWt3TUtPT2pTTWJkUHJFTXJwVWwzbTNqOERReWNGcU8ydHc9XCIsXCJhdWRcIjpcImRpZDptYWdpYzpkNGMwMjgxYi04YzViLTQ5NDMtODUwOS0xNDIxNzUxYTNjNzdcIixcIm5iZlwiOjE1ODUwMTA4MzUsXCJ0aWRcIjpcImFjMmE4YzFjLWE4OWEtNDgwOC1hY2QxLWM1ODg1ZTI2YWZiY1wiLFwiYWRkXCI6XCIweDkxZmJlNzRiZTZjNmJmZDhkZGRkZDkzMDExYjA1OWI5MjUzZjEwNzg1NjQ5NzM4YmEyMTdlNTFlMGUzZGYxMzgxZDIwZjUyMWEzNjQxZjIzZWI5OWNjYjM0ZTNiYzVkOTYzMzJmZGViYzhlZmE1MGNkYjQxNWU0NTUwMDk1MmNkMWNcIn0iXQ==';
+
+        try {
+            $this->token->validate($expired_did_token);
+        } catch (\MagicAdmin\Exception\DIDTokenException $e) {
+            static::assertSame($e->getMessage(), 'Given DID token has expired. Please generate a new one.');
+        }
+    }
+
+    public function testValidateRaisesErrorIfDidTokenCannotBeUsedYet()
+    {
+        $valid_future_marked_did_token = 'WyIweDkzZjRiNTViYzRlN2E1ZWJkZTdmMzVkYzczMWE5NWFmOGYwZjVlMWQyMWQ5ZDYwZWQxM2Y4YmYzMmNiN2UwOTQ1MDM0MGI1Y2IyNTIxODZkNWQ3OTFiOTAyODZhYmY1NzM3YzMxN2M5NzNhMmQzMGY0MWZmYmFlNGU0NTdmMjE4MWIiLCJ7XCJpYXRcIjoxNTkxOTE0NTgyLFwiZXh0XCI6MjIyMjcxNDU4MixcImlzc1wiOlwiZGlkOmV0aHI6MHg0YzMzMmQ5QzRhMmEwNjY1YzNmODg1MTU1YjlFOTFmZEIzMDBlRTc2XCIsXCJzdWJcIjpcIms4NUtaR09Ycl9vMTYxNGdFVGN6Yzlac0phTjV4cjF2TVFXSWhnbjQ1Slk9XCIsXCJhdWRcIjpcImRpZDptYWdpYzoyMWI4ZjRkZS02ZmIzLTQ0M2YtOGM0MC04ODcwODJjNDQ1MjNcIixcIm5iZlwiOjE5MDczMTQ1ODIsXCJ0aWRcIjpcIjVhMjhjMjQwLWRmYzYtNDg2Ni04ODk1LTVkYzBhOTVkNWJkN1wiLFwiYWRkXCI6XCIweGRlMmI1ODgyNjUyZGExOTY4YWNlZTIyYWUyNGI2OWYxNThlZjg1NDQzOGE0OTlmMThjZGZlZDU3MzEwOGIxNzExYjQ2OWQ3MzQ5NzdhNGQ4NGJlM2RiODc2OTBkZjFmZjk4MTVjN2Y3NDIxNjIxMGY4Y2JhMGJmYzQ2ZGIwYjhkMWNcIn0iXQ==';
+
+        try {
+            $this->token->validate($valid_future_marked_did_token);
+        } catch (\MagicAdmin\Exception\DIDTokenException $e) {
+            static::assertSame($e->getMessage(), 'Given DID token cannot be used at this time. Please check the "nbf" field and regenerate a new token with a suitable value.');
+        }
+    }
+}

--- a/tests/Util/EthTest.php
+++ b/tests/Util/EthTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use MagicAdmin\Util\Eth;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+final class EthTest extends TestCase
+{
+    public function testEcRecover()
+    {
+        $tests = [
+            [
+                'address' => '0xbe93f9bacbcffc8ee6663f2647917ed7a20a57bb',
+                'message' => 'hello world',
+                'signature' => '0xce909e8ea6851bc36c007a0072d0524b07a3ff8d4e623aca4c71ca8e57250c4d0a3fc38fa8fbaaa81ead4b9f6bd03356b6f8bf18bccad167d78891636e1d69561b',
+            ],
+            [
+                'address' => '0xe651c5051ce42241765bbb24655a791ff0ec8d13',
+                'message' => 'wee test message 18/09/2017 02:55PM',
+                'signature' => '0xf5ac62a395216a84bd595069f1bb79f1ee08a15f07bb9d9349b3b185e69b20c60061dbe5cdbe7b4ed8d8fea707972f03c21dda80d99efde3d96b42c91b2703211b',
+            ],
+            [
+                'address' => '0x9283099a29556fcf8fff5b2cea2d4f67cb7a7a8b',
+                'message' => 'I am but a stack exchange post',
+                'signature' => '0x0cf7e2e1cbaf249175b8e004118a182eb378a0b78a7a741e72a0a34e970b59194aa4d9419352d181a4d1827abbad279ad4f5a7b60da5751b82fec4dde6f380a51b',
+            ],
+            [
+                'address' => '0xb61f34dc82977e2b8c2bd747284b47ab94615bff',
+                'message' => 'I want to create a Account on this website. By I signing this text (using Ethereum personal_sign) I agree to the following conditions.',
+                'signature' => '0xbbdcdfb9fbe24d460a683633475c77a44072b527a127b159ffaaa043f5dc944105a1671c8b9df95e377d89ec17a1a0ed13f5caa33e5fa80bdf12391bf2e04e4f1c',
+            ],
+            [
+                'address' => '0xb61f34dc82977e2b8c2bd747284b47ab94615bff',
+                'message' => 'I want to create a Account on this website. By I signing this text (using Ethereum personal_sign) I agree to the following conditions.',
+                'signature' => '0xbbdcdfb9fbe24d460a683633475c77a44072b527a127b159ffaaa043f5dc944105a1671c8b9df95e377d89ec17a1a0ed13f5caa33e5fa80bdf12391bf2e04e4f1c',
+            ],
+        ];
+
+        foreach ($tests as $test) {
+            $actualSigner = Eth::ecRecover($test['message'], $test['signature']);
+            $expectedSigner = $test['address'];
+
+            static::assertSame($actualSigner, $expectedSigner);
+        }
+    }
+}


### PR DESCRIPTION
### 📦 Pull Request

This pull implements an alternate ecRecover process internally as opposed to using [digitaldonkey/ecverify](https://github.com/digitaldonkey/ecverify). This is due to the reasons described in [this issue](https://github.com/digitaldonkey/ecverify/issues/2). In summary this pull will allow this package to support runtimes that do not have the `gmp` extension installed as long as the `bcmath` extension is installed.

No new functionality has been introduced.

One thing to note is that although calls to `$magic->token->validate()` will work without `gmp` as long as `bcmath` is installed, there is a significant performance difference between the two. This is why the [simplito/bigint-wrapper-php](https://github.com/simplito/bigint-wrapper-php) sub-dependency is designed to work with `gmp` first and `bcmath` as a fallback.

On average calls to  `$magic->token->validate()`  took about 17ms with `gmp` versus 320ms with `bcmath`. In apps where validate is being called on every request this may be a showstopper for some users.

Users should be encouraged to install `gmp` whenever possible, but also made aware that the package will work with `bcmath` as an alternative. Currently there are various hosting platforms that do not support `gmp`, like Laravel Vapor for example.


### 🗜 Versioning

(Check _one!_)

- [x] Patch: Bug Fix?
- [ ] Minor: New Feature?
- [ ] Major: Breaking Change?